### PR TITLE
Add error handling for unlock devices

### DIFF
--- a/setup-tools/unlock-devices.sh
+++ b/setup-tools/unlock-devices.sh
@@ -74,7 +74,10 @@ do
     echo "Start unlocking the device with ip address $DEVICE_IP"
 
     # Unlock device
-    $SNOWBALLEDGE_CLIENT_PATH unlock-device --endpoint https://$DEVICE_IP --manifest-file $MANIFEST_PATH --unlock-code $UNLOCK_CODE
+    if ! $SNOWBALLEDGE_CLIENT_PATH unlock-device --endpoint https://$DEVICE_IP --manifest-file $MANIFEST_PATH --unlock-code $UNLOCK_CODE; then
+      echo "Failed to unlock the device: $DEVICE_IP"
+      exit
+    fi
 
     # Check unlock status
     UNLOCK_STATUS=$($SNOWBALLEDGE_CLIENT_PATH describe-device --endpoint https://$DEVICE_IP --manifest-file $MANIFEST_PATH --unlock-code $UNLOCK_CODE | jq -r '.UnlockStatus.State')
@@ -84,7 +87,7 @@ do
       UNLOCK_STATUS=$($SNOWBALLEDGE_CLIENT_PATH describe-device --endpoint https://$DEVICE_IP --manifest-file $MANIFEST_PATH --unlock-code $UNLOCK_CODE | jq -r '.UnlockStatus.State')
       if [ $UNLOCK_STATUS == LOCKED ]
       then
-        echo "The device with ip address: $DEVICE_IP falls to LOCKED status. Unlocking process failed. Exiting..."
+        echo "Failed to unlock device: $DEVICE_IP"
         exit
       fi
     done


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add error handling for unlock devices

*Tests*
Happy Path:
```
[awsie@snow-mxq2330hpm ~]$ ./unlock-devices.sh 
Start unlocking the device with ip address 192.168.1.177
Start unlocking the device with ip address 192.168.1.109
Start unlocking the device with ip address 192.168.1.76
Your Snowball Edge device is unlocking. You may determine the unlock state of your device using the describe-device command. Your Snowball Edge device will be available for use when it is in the UNLOCKED state.
Your Snowball Edge device is unlocking. You may determine the unlock state of your device using the describe-device command. Your Snowball Edge device will be available for use when it is in the UNLOCKED state.
Your Snowball Edge device is unlocking. You may determine the unlock state of your device using the describe-device command. Your Snowball Edge device will be available for use when it is in the UNLOCKED state.
The device with ip address: 192.168.1.76 has been unlocked
The device with ip address: 192.168.1.109 has been unlocked
The device with ip address: 192.168.1.177 has been unlocked
```
With incorrect manifest path of device of IP: 192.168.1.109
```
[awsie@snow-mxq2330hpm ~]$ ./unlock-devices.sh 
Start unlocking the device with ip address 192.168.1.109
Start unlocking the device with ip address 192.168.1.76
Start unlocking the device with ip address 192.168.1.177
SdkClientException - Unable to execute HTTP request: PKIX path building failed: sun.security.provider.certpath.SunCertPathBuilderException: unable to find valid certification path to requested target
Failed to unlock the device: 192.168.1.109
Your Snowball Edge device is unlocking. You may determine the unlock state of your device using the describe-device command. Your Snowball Edge device will be available for use when it is in the UNLOCKED state.
Your Snowball Edge device is unlocking. You may determine the unlock state of your device using the describe-device command. Your Snowball Edge device will be available for use when it is in the UNLOCKED state.
The device with ip address: 192.168.1.76 has been unlocked
The device with ip address: 192.168.1.177 has been unlocked
```
With incorrect unlock code of device of IP: 192.168.1.177
```
[awsie@snow-mxq2330hpm ~]$ ./unlock-devices.sh 
Start unlocking the device with ip address 192.168.1.177
Start unlocking the device with ip address 192.168.1.109
Start unlocking the device with ip address 192.168.1.76
RuntimeException - The provided manifest is invalid. Ensure the unlock code and the manifest file are correct.
Failed to unlock the device: 192.168.1.177
Your Snowball Edge device is unlocking. You may determine the unlock state of your device using the describe-device command. Your Snowball Edge device will be available for use when it is in the UNLOCKED state.
Your Snowball Edge device is unlocking. You may determine the unlock state of your device using the describe-device command. Your Snowball Edge device will be available for use when it is in the UNLOCKED state.
The device with ip address: 192.168.1.109 has been unlocked
The device with ip address: 192.168.1.76 has been unlocked
```
The device is not accessible
```
[awsie@snow-mxq2330hpm ~]$ ./unlock-devices.sh 
Start unlocking the device with ip address 192.168.1.177
Start unlocking the device with ip address 192.168.1.109
Start unlocking the device with ip address 1921.168.1.76
URISyntaxException - Expected scheme-specific part at index 6: https:
Failed to unlock the device: 1921.168.1.76
Your Snowball Edge device is unlocking. You may determine the unlock state of your device using the describe-device command. Your Snowball Edge device will be available for use when it is in the UNLOCKED state.
Your Snowball Edge device is unlocking. You may determine the unlock state of your device using the describe-device command. Your Snowball Edge device will be available for use when it is in the UNLOCKED state.
The device with ip address: 192.168.1.109 has been unlocked
The device with ip address: 192.168.1.177 has been unlocked
```
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
