### PR TITLE
Fix invalid container image path bug

### DIFF
--- a/container-registry-ami-builder/preload-images.sh
+++ b/container-registry-ami-builder/preload-images.sh
@@ -1,9 +1,8 @@
 #!/bin/bash
 set -euo pipefail
 
-OLD='/'
-NEW='-'
 FILE="images.txt"
+
 #Check images.txt, skipping empty lines in the file and docker pull all images listed in the file
 while IFS= read -r IMAGE
 do
@@ -11,6 +10,5 @@ do
     continue
   fi
   sudo docker pull $IMAGE
-  NEW_OUT=$(echo $IMAGE | sed 's/\\$OLD/\\$NEW/g')
-  sudo docker save $IMAGE > images/$NEW_OUT.tar
+  sudo docker save $IMAGE > images/$(echo $IMAGE | sed 's/\//\-/g').tar
 done < "$FILE"


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-samples/aws-snow-tools-for-eks-anywhere/issues/19

*Description of changes:*
* replace `/` with `-` in image path

*Testing:*
```
[ec2-user@ip-34-223-14-195 ~]$ IMAGE=public.ecr.aws/eks-anywhere/kubernetes-sigs/kind/node
[ec2-user@ip-34-223-14-195 ~]$ docker save $IMAGE > images/$(echo $IMAGE | sed 's/\//\-/g').tar
[ec2-user@ip-34-223-14-195 ~]$ ls images/
public.ecr.aws-eks-anywhere-kubernetes-sigs-kind-node.tar
[ec2-user@ip-34-223-14-195 ~]$
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
