### PR TITLE
removed '-e' from cert file and updated README with Mac instruction

### DIFF
--- a/setup-tools/README.md
+++ b/setup-tools/README.md
@@ -6,12 +6,17 @@ There are 4 scripts in this folder which can help to setup a EKS Anywhere on Sno
 
 ## Prerequisites
 1. Install jq
+* Linux
+  ```
+  curl -qL -o jq https://stedolan.github.io/jq/download/linux64/jq && chmod +x ./jq
+  ```
+  * Add jq to PATH
+  ```
+  export PATH=$PATH:<path to jq>
+  ```
+* Mac
 ```
-curl -qL -o jq https://stedolan.github.io/jq/download/linux64/jq && chmod +x ./jq
-```
-2. Add jq to your PATH
-```
-export PATH=$PATH:<path to jq>
+brew install jq
 ```
 3. Install snowballEdge cli at [Downloading and Installing the Snowball Edge Client](https://docs.aws.amazon.com/snowball/latest/developer-guide/using-client.html#download-client)
 4. Install aws cli at [Installing or updating the latest version of the AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html)

--- a/setup-tools/create-creds-and-certs-files.sh
+++ b/setup-tools/create-creds-and-certs-files.sh
@@ -126,7 +126,7 @@ do
   EKS_A_SECRET_ACCESS_KEY=$(jq -r '.AccessKey.SecretAccessKey' <<< "$CREDENTIALS")
 
   # Save the scope down credentials
-  echo -e "[$DEVICE_IP]\naws_access_key_id = $EKS_A_ACCESS_KEY_ID\naws_secret_access_key = $EKS_A_SECRET_ACCESS_KEY\nregion = snow\n\n" >> $CREDS_FILE
+  echo "[$DEVICE_IP]\naws_access_key_id = $EKS_A_ACCESS_KEY_ID\naws_secret_access_key = $EKS_A_SECRET_ACCESS_KEY\nregion = snow\n\n" >> $CREDS_FILE
   echo "Finish setting up snowball_creds file for the device with the IP Address $DEVICE_IP"
 
   # Save certificates

--- a/setup-tools/create-creds-and-certs-files.sh
+++ b/setup-tools/create-creds-and-certs-files.sh
@@ -126,7 +126,7 @@ do
   EKS_A_SECRET_ACCESS_KEY=$(jq -r '.AccessKey.SecretAccessKey' <<< "$CREDENTIALS")
 
   # Save the scope down credentials
-  echo "[$DEVICE_IP]\naws_access_key_id = $EKS_A_ACCESS_KEY_ID\naws_secret_access_key = $EKS_A_SECRET_ACCESS_KEY\nregion = snow\n\n" >> $CREDS_FILE
+  printf "[$DEVICE_IP]\naws_access_key_id = $EKS_A_ACCESS_KEY_ID\naws_secret_access_key = $EKS_A_SECRET_ACCESS_KEY\nregion = snow\n\n" >> $CREDS_FILE
   echo "Finish setting up snowball_creds file for the device with the IP Address $DEVICE_IP"
 
   # Save certificates

--- a/setup-tools/create-eks-a-admin-instance.sh
+++ b/setup-tools/create-eks-a-admin-instance.sh
@@ -138,7 +138,7 @@ then
   echo "Creating cluster config on the eksa admin instance"
   sh ./generate-cluster-config.sh /tmp/$KEY_NAME.pem $PUBLIC_IP
   echo "Successfully created cluster config file /home/ec2-user/eksa-cluster-$CLUSTER_NAME.yaml on the EKS Anywhere admin instance"
-  echo -e "Once your are on the admin instance, run the following command to create a cluster: \nsh ~/create-cluster-$CLUSTER_NAME.sh"
+  printf "Once your are on the admin instance, run the following command to create a cluster: \nsh ~/create-cluster-$CLUSTER_NAME.sh"
 fi
 
-echo -e "EKS Anywhere admin instance was successfully configured, you can ssh to it now using command: \nssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i /tmp/$KEY_NAME.pem ec2-user@$PUBLIC_IP"
+printf "EKS Anywhere admin instance was successfully configured, you can ssh to it now using command: \nssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i /tmp/$KEY_NAME.pem ec2-user@$PUBLIC_IP"

--- a/setup-tools/generate-cluster-config.sh
+++ b/setup-tools/generate-cluster-config.sh
@@ -23,20 +23,20 @@ set -euo pipefail
 
 EOF
 
-echo -e "eksctl anywhere generate clusterconfig $CLUSTER_NAME -p snow > ~/eksa-cluster-$CLUSTER_NAME.yaml" >> /tmp/generate-cluster-config.sh
+printf "eksctl anywhere generate clusterconfig $CLUSTER_NAME -p snow > ~/eksa-cluster-$CLUSTER_NAME.yaml\n" >> /tmp/generate-cluster-config.sh
 
 # add control plane endpoint if provided
 CONTROL_PLANE_ENDPOINT=$(jq -r '.ControlPlaneEndpoint' $CONFIG_FILE)
 if [[ ! -z $CONTROL_PLANE_ENDPOINT ]]
 then
-  echo -e "sed -i 's/      host: \"\"/      host: \"$CONTROL_PLANE_ENDPOINT\"/' ~/eksa-cluster-$CLUSTER_NAME.yaml" >> /tmp/generate-cluster-config.sh
+  printf "sed -i 's/      host: \"\"/      host: \"$CONTROL_PLANE_ENDPOINT\"/' ~/eksa-cluster-$CLUSTER_NAME.yaml\n" >> /tmp/generate-cluster-config.sh
 fi
 
 # modify kubernetes version if provided
 KUBERNETES_VERSION=$(jq -r '.KubernetesVersion' $CONFIG_FILE)
 if [[ ! -z $KUBERNETES_VERSION ]]
 then
-  echo -e "sed -i '/kubernetesVersion:/s/.*/  kubernetesVersion: $KUBERNETES_VERSION/' ~/eksa-cluster-$CLUSTER_NAME.yaml" >> /tmp/generate-cluster-config.sh
+  printf "sed -i '/kubernetesVersion:/s/.*/  kubernetesVersion: $KUBERNETES_VERSION/' ~/eksa-cluster-$CLUSTER_NAME.yaml\n" >> /tmp/generate-cluster-config.sh
 fi
 
 # modify pod cidr if provided
@@ -44,7 +44,7 @@ POD_CIDR=$(jq -r '.PodCIDR' $CONFIG_FILE)
 if [[ ! -z $POD_CIDR ]]
 then
   POD_CIDR=$(echo $POD_CIDR | sed 's/\//\\\//')
-  echo -e "sed -i 's/      - 192.168.0.0\/16/      - $POD_CIDR/' ~/eksa-cluster-$CLUSTER_NAME.yaml" >> /tmp/generate-cluster-config.sh
+  printf "sed -i 's/      - 192.168.0.0\/16/      - $POD_CIDR/' ~/eksa-cluster-$CLUSTER_NAME.yaml\n" >> /tmp/generate-cluster-config.sh
 fi
 
 # modify service cidr if provided
@@ -52,30 +52,32 @@ SERVICE_CIDR=$(jq -r '.ServiceCIDR' $CONFIG_FILE)
 if [[ ! -z $SERVICE_CIDR ]]
 then
   SERVICE_CIDR=$(echo $SERVICE_CIDR | sed 's/\//\\\//')
-  echo -e "sed -i 's/      - 10.96.0.0/12/      - $SERVICE_CIDR/' ~/eksa-cluster-$CLUSTER_NAME.yaml" >> /tmp/generate-cluster-config.sh
+  printf "sed -i 's/      - 10.96.0.0\/12/      - $SERVICE_CIDR/' ~/eksa-cluster-$CLUSTER_NAME.yaml\n" >> /tmp/generate-cluster-config.sh
 fi
 
 # modify instance type if provided
 INSTANCE_TYPE=$(jq -r '.InstanceType' $CONFIG_FILE)
 if [[ ! -z $INSTANCE_TYPE ]]
 then
-  echo -e "sed -i '/instanceType:/s/.*/  instanceType: $INSTANCE_TYPE/' ~/eksa-cluster-$CLUSTER_NAME.yaml" >> /tmp/generate-cluster-config.sh
+  printf "sed -i '/instanceType:/s/.*/  instanceType: $INSTANCE_TYPE/' ~/eksa-cluster-$CLUSTER_NAME.yaml\n" >> /tmp/generate-cluster-config.sh
 fi
 
 # modify physical network connector type if provided
 PHYSICAL_NETWORK_CONNECTOR=$(jq -r '.PhysicalNetworkConnector' $CONFIG_FILE)
 if [[ ! -z $PHYSICAL_NETWORK_CONNECTOR ]]
 then
-  echo -e "sed -i '/physicalNetworkConnector:/s/.*/  physicalNetworkConnector: $PHYSICAL_NETWORK_CONNECTOR/' ~/eksa-cluster-$CLUSTER_NAME.yaml" >> /tmp/generate-cluster-config.sh
+  printf "sed -i '/physicalNetworkConnector:/s/.*/  physicalNetworkConnector: $PHYSICAL_NETWORK_CONNECTOR/' ~/eksa-cluster-$CLUSTER_NAME.yaml\n" >> /tmp/generate-cluster-config.sh
 fi
 
 # TODO add registry mirror if provided
 
 # add device ips to machine template device list
-echo "sed -i 's/  - \"\"/$DEVICE_LIST/' ~/eksa-cluster-$CLUSTER_NAME.yaml" >> /tmp/generate-cluster-config.sh
+cat <<EOF>> /tmp/generate-cluster-config.sh
+sed -i 's/  - \"\"/$DEVICE_LIST/' ~/eksa-cluster-$CLUSTER_NAME.yaml
+EOF
 
 # remove empty lines
-echo -e "sed -i '/^$/d' ~/eksa-cluster-$CLUSTER_NAME.yaml" >> /tmp/generate-cluster-config.sh
+printf "sed -i '/^$/d' ~/eksa-cluster-$CLUSTER_NAME.yaml" >> /tmp/generate-cluster-config.sh
 
 
 # TODO add image import command if registry mirror information is provided

--- a/setup-tools/harbor-setup.sh
+++ b/setup-tools/harbor-setup.sh
@@ -88,4 +88,4 @@ unset AWS_SECRET_ACCESS_KEY
 unset AWS_DEFAULT_REGION
 echo "Successfully created harbor registry instance $INSTANCE_ID on device with ip $DEVICE_IP and attached public ip $PUBLIC_IP on it"
 
-echo -e "Harbor registry instance was successfully configured, you can ssh to it now using command: \nssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i /tmp/$KEY_NAME.pem ec2-user@$PUBLIC_IP"
+printf "Harbor registry instance was successfully configured, you can ssh to it now using command: \nssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i /tmp/$KEY_NAME.pem ec2-user@$PUBLIC_IP"


### PR DESCRIPTION
*Issue #, if available:*
21

*Description of changes:*
* Replaced use of `echo -e` with `printf` for portability between Mac and Linux
* Updated REAME with instructions for installing jq on Mac.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
