### PR TITLE
Support generating and importing node instance ssh key

### DIFF
--- a/setup-tools/config.json
+++ b/setup-tools/config.json
@@ -19,5 +19,6 @@
   "ServiceCIDR": "",
   "KubernetesVersion": "",
   "InstanceType": "",
-  "PhysicalNetworkConnector": ""
+  "PhysicalNetworkConnector": "",
+  "SshKeyName":""
 }


### PR DESCRIPTION
*Issue #, if available:*
eksa v0.19 will remove node instance ssh key generation. 

*Description of changes:*
add node instance ssh key generating and importing logic.

*Testing:*
tested on beta device, successfully generated cluster config and created a cluster

```
dev-dsk-chy-2c-59ad9092 % sh generate-cluster-config.sh /tmp/eksa-admin-instance-key-1706219838.pem 10.186.0.164
ssh key chy-test-key exists on all devices
Warning: Permanently added '10.186.0.164' (ECDSA) to the list of known hosts.
generate-cluster-config.sh                                                                                                                                                100%  513   184.8KB/s   00:00
create-cluster-chy-test-new.sh                                                                                                                                            100%  241    93.7KB/s   00:00
Warning: Permanently added '10.186.0.164' (ECDSA) to the list of known hosts.

(24-01-26 17:57:12) <0> [/tmp/aws-snow-tools-for-eks-anywhere/setup-tools]
dev-dsk-chy-2c-59ad9092 %
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
